### PR TITLE
PR: release-2.6.0 -> master (fix rtd config validation error in `format`)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,8 @@ sphinx:
   # Fail on all warnings to avoid broken references
   fail_on_warning: true
 
-formats: html
+formats:
+  - html
 
 # Set the OS, Python version and other tools you might need
 build:


### PR DESCRIPTION
(docs) fix: rtd config validation error in
Expected a list, got type str (html) (this is the log from failed rtd build)